### PR TITLE
Made sizeable jellyfish compatible with S&R growth potions

### DIFF
--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
@@ -16,6 +16,7 @@ import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.IServerWorld;
 import net.minecraft.world.World;
 
+import java.util.Random;
 import java.util.TreeMap;
 
 public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEntity implements IAgeableEntity {
@@ -63,8 +64,9 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 		spawnDataIn = super.onInitialSpawn(worldIn, difficultyIn, reason, spawnDataIn, dataTag);
 		boolean updateSize = false;
 
-		int color = this.getRNG().nextInt(3);
-		float size = this.getSizeMap().randomSize(this.getRNG());
+		Random rand = this.getRNG();
+		int color = rand.nextInt(3);
+		float size = this.getSizeMap().randomSize(rand);
 		if (!(dataTag != null && this.isFromBucket())) {
 			if (spawnDataIn instanceof SpawnData) {
 				size = ((SpawnData) spawnDataIn).size;

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
@@ -66,7 +66,7 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 
 		Random rand = this.getRNG();
 		int color = rand.nextInt(3);
-		float size = this.getSizeMap().randomSize(rand);
+		float size = this.getNaturalSizeMap().randomSize(rand);
 		if (!(dataTag != null && this.isFromBucket())) {
 			if (spawnDataIn instanceof SpawnData) {
 				size = ((SpawnData) spawnDataIn).size;
@@ -84,16 +84,16 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 		return spawnDataIn;
 	}
 
-	public JellyfishSizeMap getSizeMap() {
-		return NATURAL_SIZES;
-	}
-
 	public int getColor() {
 		return this.dataManager.get(COLOR);
 	}
 
 	public void setColor(int color) {
 		this.dataManager.set(COLOR, color);
+	}
+
+	public JellyfishSizeMap getNaturalSizeMap() {
+		return NATURAL_SIZES;
 	}
 
 	public void setSize(float size, boolean updateHealth) {
@@ -120,7 +120,7 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 	@Override
 	public boolean canAge(boolean isGrowing) {
 		float size = this.getSize();
-		JellyfishSizeMap map = this.getSizeMap();
+		JellyfishSizeMap map = this.getNaturalSizeMap();
 		if (map.containsKey(size)) {
 			return (isGrowing ? map.higherKey(size) : map.lowerKey(size)) != null;
 		}
@@ -130,7 +130,7 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 	@Override
 	public LivingEntity attemptAging(boolean isGrowing) {
 		float size = this.getSize();
-		JellyfishSizeMap map = this.getSizeMap();
+		JellyfishSizeMap map = this.getNaturalSizeMap();
 		if (map.containsKey(size)) {
 			Float newSize = isGrowing ? map.higherKey(size) : map.lowerKey(size);
 			if (newSize != null) this.setSize(newSize, false);

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
@@ -131,7 +131,7 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 		JellyfishSizeMap map = this.getSizeMap();
 		if (map.containsKey(size)) {
 			Float newSize = isGrowing ? map.higherKey(size) : map.lowerKey(size);
-			if(newSize != null) this.setSize(newSize, false);
+			if (newSize != null) this.setSize(newSize, false);
 		}
 		return this;
 	}

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
@@ -1,7 +1,9 @@
 package com.minecraftabnormals.upgrade_aquatic.common.entities.jellyfish;
 
+import com.minecraftabnormals.abnormals_core.core.api.IAgeableEntity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ILivingEntityData;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.nbt.CompoundNBT;
@@ -12,7 +14,7 @@ import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.IServerWorld;
 import net.minecraft.world.World;
 
-public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEntity {
+public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEntity implements IAgeableEntity {
 	protected static final DataParameter<Integer> COLOR = EntityDataManager.createKey(ColoredSizableJellyfishEntity.class, DataSerializers.VARINT);
 	protected static final DataParameter<Float> SIZE = EntityDataManager.createKey(ColoredSizableJellyfishEntity.class, DataSerializers.FLOAT);
 	private final ColoredSizableBucketProcessor bucketProcessor;
@@ -93,6 +95,39 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 
 	public float getSize() {
 		return this.dataManager.get(SIZE);
+	}
+
+	@Override
+	public boolean hasGrowthProgress() {
+		return false;
+	}
+
+	@Override
+	public void resetGrowthProgress() {
+	}
+
+	@Override
+	public boolean canAge(boolean isGrowing) {
+		return this.getSize() == 0.65F || (this.getSize() == 0.5F ? isGrowing : this.getSize() == 1.0F && !isGrowing);
+	}
+
+	@Override
+	public LivingEntity attemptAging(boolean isGrowing) {
+		float size = this.getSize();
+		float newSize = 0;
+		if (size == 0.65F) {
+			newSize = isGrowing ? 1.0F : 0.5F;
+		}
+		else if (size == 0.5F && isGrowing) {
+			newSize = 0.65F;
+		}
+		else if (size == 1.0F && !isGrowing) {
+			newSize = 0.65F;
+		}
+		if(newSize != 0) {
+			this.setSize(newSize, false);
+		}
+		return this;
 	}
 
 	@Override

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
@@ -20,7 +20,7 @@ import java.util.TreeMap;
 public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEntity implements IAgeableEntity {
 	protected static final DataParameter<Integer> COLOR = EntityDataManager.createKey(ColoredSizableJellyfishEntity.class, DataSerializers.VARINT);
 	protected static final DataParameter<Float> SIZE = EntityDataManager.createKey(ColoredSizableJellyfishEntity.class, DataSerializers.FLOAT);
-	protected TreeMap<Float, Integer> sizes = new TreeMap<>(ImmutableMap.of(0.5F, 3, 0.65F, 3, 1.0F, 34));
+	protected TreeMap<Float, Integer> naturalSpawningSizes = new TreeMap<>(ImmutableMap.of(0.5F, 3, 0.65F, 3, 1.0F, 34));
 	private final ColoredSizableBucketProcessor bucketProcessor;
 
 	public ColoredSizableJellyfishEntity(EntityType<? extends AbstractJellyfishEntity> type, World world) {
@@ -63,10 +63,10 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 		boolean updateSize = false;
 		float size = 0;
 		int denominator = 0;
-		for (int weight : sizes.values())
+		for (int weight : naturalSpawningSizes.values())
 			denominator += weight;
-		for (float currentSize : sizes.keySet()) {
-			int weight = sizes.get(currentSize);
+		for (float currentSize : naturalSpawningSizes.keySet()) {
+			int weight = naturalSpawningSizes.get(currentSize);
 			if (this.getRNG().nextInt(denominator) < weight) {
 				size = currentSize;
 				break;
@@ -123,8 +123,8 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 
 	@Override
 	public boolean canAge(boolean isGrowing) {
-		if (sizes.containsKey(this.getSize())) {
-			Float newSize = isGrowing ? sizes.higherKey(this.getSize()) : sizes.lowerKey(this.getSize());
+		if (naturalSpawningSizes.containsKey(this.getSize())) {
+			Float newSize = isGrowing ? naturalSpawningSizes.higherKey(this.getSize()) : naturalSpawningSizes.lowerKey(this.getSize());
 			return newSize != null;
 		}
 		return false;
@@ -132,8 +132,8 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 
 	@Override
 	public LivingEntity attemptAging(boolean isGrowing) {
-		if (sizes.containsKey(this.getSize())) {
-			Float newSize = isGrowing ? sizes.higherKey(this.getSize()) : sizes.lowerKey(this.getSize());
+		if (naturalSpawningSizes.containsKey(this.getSize())) {
+			Float newSize = isGrowing ? naturalSpawningSizes.higherKey(this.getSize()) : naturalSpawningSizes.lowerKey(this.getSize());
 			if(newSize != null) this.setSize(newSize, false);
 		}
 		return this;

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/ColoredSizableJellyfishEntity.java
@@ -22,7 +22,7 @@ import java.util.TreeMap;
 public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEntity implements IAgeableEntity {
 	protected static final DataParameter<Integer> COLOR = EntityDataManager.createKey(ColoredSizableJellyfishEntity.class, DataSerializers.VARINT);
 	protected static final DataParameter<Float> SIZE = EntityDataManager.createKey(ColoredSizableJellyfishEntity.class, DataSerializers.FLOAT);
-	private static final JellyfishSizeMap naturalSpawningSizes = new JellyfishSizeMap(new TreeMap<>(ImmutableMap.of(0.5F, 3, 0.65F, 3, 1.0F, 34)));
+	private static final JellyfishSizeMap NATURAL_SIZES = new JellyfishSizeMap(new TreeMap<>(ImmutableMap.of(0.5F, 3, 0.65F, 3, 1.0F, 34)));
 	private final ColoredSizableBucketProcessor bucketProcessor;
 
 	public ColoredSizableJellyfishEntity(EntityType<? extends AbstractJellyfishEntity> type, World world) {
@@ -85,7 +85,7 @@ public abstract class ColoredSizableJellyfishEntity extends AbstractJellyfishEnt
 	}
 
 	public JellyfishSizeMap getSizeMap() {
-		return naturalSpawningSizes;
+		return NATURAL_SIZES;
 	}
 
 	public int getColor() {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
@@ -3,11 +3,8 @@ package com.minecraftabnormals.upgrade_aquatic.common.entities.jellyfish.helper;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
-import java.util.NavigableMap;
-import java.util.NavigableSet;
 import java.util.Random;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class JellyfishSizeMap {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
@@ -1,5 +1,8 @@
 package com.minecraftabnormals.upgrade_aquatic.common.entities.jellyfish.helper;
 
+import com.minecraftabnormals.abnormals_core.core.AbnormalsCore;
+import org.apache.logging.log4j.Level;
+
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
@@ -11,12 +14,13 @@ public class JellyfishSizeMap {
     protected final TreeMap<Float, Integer> sizeMap;
     private final int totalWeight;
 
-    public JellyfishSizeMap(TreeMap<Float, Integer> map) {
-        this.sizeMap = map;
-        int weightTotal = 0;
+    public JellyfishSizeMap(TreeMap<Float, Integer> sizeMap) {
+        this.sizeMap = sizeMap;
+        int totalWeight = 0;
         for (int weight : this.sizeMap.values())
-            weightTotal += weight;
-        this.weightTotal = weightTotal;
+            totalWeight += weight;
+        this.totalWeight = totalWeight;
+        if(this.sizeMap.isEmpty()) AbnormalsCore.LOGGER.throwing(Level.ERROR, new IllegalArgumentException("[Upgrade Aquatic] Inputted size map for JellyfishSizeMap cannot be empty!"));
     }
 
     public int size() {
@@ -24,11 +28,11 @@ public class JellyfishSizeMap {
     }
 
     public int getTotalWeight() {
-        return this.weightTotal;
+        return this.totalWeight;
     }
 
     public float randomSize(Random rand) throws RuntimeException {
-        int denominator = totalWeight();
+        int denominator = this.getTotalWeight();
         for (Map.Entry<Float, Integer> sizeEntry : this.entrySet()) {
             int weight = sizeEntry.getValue();
             if (rand.nextInt(denominator) < weight) {
@@ -36,7 +40,7 @@ public class JellyfishSizeMap {
             }
             denominator = denominator - weight;
         }
-       throw new RuntimeException("JellyfishSizeMap in Upgrade Aquatic has broken. This should not be happening!");
+        return 0;
     }
 
     public boolean containsKey(Float key) {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
@@ -1,7 +1,7 @@
 package com.minecraftabnormals.upgrade_aquatic.common.entities.jellyfish.helper;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -47,12 +47,9 @@ public class JellyfishSizeMap {
         return this.sizeMap.containsValue(value);
     }
 
+    @Nullable
     public Integer get(Float key) {
         return this.sizeMap.get(key);
-    }
-
-    public Comparator<? super Float> comparator() {
-        return this.sizeMap.comparator();
     }
 
     public Float firstKey() {
@@ -66,39 +63,27 @@ public class JellyfishSizeMap {
     public Map.Entry<Float, Integer> firstEntry() {
         return this.sizeMap.firstEntry();
     }
-    
+
     public Map.Entry<Float, Integer> lastEntry() {
         return this.sizeMap.lastEntry();
     }
-    
+
+    @Nullable
     public Map.Entry<Float, Integer> lowerEntry(Float key) {
         return this.sizeMap.lowerEntry(key);
     }
-    
+
+    @Nullable
     public Float lowerKey(Float key) {
         return this.sizeMap.lowerKey(key);
     }
-    
-    public Map.Entry<Float, Integer> floorEntry(Float key) {
-        return this.sizeMap.floorEntry(key);
-    }
-    
-    public Float floorKey(Float key) {
-        return this.sizeMap.floorKey(key);
-    }
-    
-    public Map.Entry<Float, Integer> ceilingEntry(Float key) {
-        return this.sizeMap.ceilingEntry(key);
-    }
-    
-    public Float ceilingKey(Float key) {
-        return this.sizeMap.ceilingKey(key);
-    }
 
+    @Nullable
     public Map.Entry<Float, Integer> higherEntry(Float key) {
         return this.sizeMap.higherEntry(key);
     }
-    
+
+    @Nullable
     public Float higherKey(Float key) {
         return this.sizeMap.higherKey(key);
     }

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
@@ -9,7 +9,7 @@ import java.util.TreeMap;
 
 public class JellyfishSizeMap {
     protected final TreeMap<Float, Integer> sizeMap;
-    protected final int weightTotal;
+    private final int totalWeight;
 
     public JellyfishSizeMap(TreeMap<Float, Integer> map) {
         this.sizeMap = map;
@@ -23,7 +23,7 @@ public class JellyfishSizeMap {
         return this.sizeMap.size();
     }
 
-    public int totalWeight() {
+    public int getTotalWeight() {
         return this.weightTotal;
     }
 

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
@@ -20,7 +20,7 @@ public class JellyfishSizeMap {
         for (int weight : this.sizeMap.values())
             totalWeight += weight;
         this.totalWeight = totalWeight;
-        if(this.sizeMap.isEmpty()) AbnormalsCore.LOGGER.throwing(Level.ERROR, new IllegalArgumentException("[Upgrade Aquatic] Inputted size map for JellyfishSizeMap cannot be empty!"));
+        if (this.sizeMap.isEmpty()) AbnormalsCore.LOGGER.error("Inputted size map cannot be empty!");
     }
 
     public int size() {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
@@ -20,14 +20,14 @@ public class JellyfishSizeMap {
     }
 
     public int size() {
-        return sizeMap.size();
+        return this.sizeMap.size();
     }
 
     public int totalWeight() {
         return this.weightTotal;
     }
 
-    public Float randomSize(Random rand) throws RuntimeException {
+    public float randomSize(Random rand) throws RuntimeException {
         int denominator = totalWeight();
         for (Map.Entry<Float, Integer> sizeEntry : this.entrySet()) {
             int weight = sizeEntry.getValue();
@@ -40,78 +40,78 @@ public class JellyfishSizeMap {
     }
 
     public boolean containsKey(Float key) {
-        return sizeMap.containsKey(key);
+        return this.sizeMap.containsKey(key);
     }
 
     public boolean containsValue(Integer value) {
-        return sizeMap.containsValue(value);
+        return this.sizeMap.containsValue(value);
     }
 
     public Integer get(Float key) {
-        return sizeMap.get(key);
+        return this.sizeMap.get(key);
     }
 
     public Comparator<? super Float> comparator() {
-        return sizeMap.comparator();
+        return this.sizeMap.comparator();
     }
 
     public Float firstKey() {
-        return sizeMap.firstKey();
+        return this.sizeMap.firstKey();
     }
 
     public Float lastKey() {
-        return sizeMap.lastKey();
+        return this.sizeMap.lastKey();
     }
 
     public Map.Entry<Float, Integer> firstEntry() {
-        return sizeMap.firstEntry();
+        return this.sizeMap.firstEntry();
     }
     
     public Map.Entry<Float, Integer> lastEntry() {
-        return sizeMap.lastEntry();
+        return this.sizeMap.lastEntry();
     }
     
     public Map.Entry<Float, Integer> lowerEntry(Float key) {
-        return sizeMap.lowerEntry(key);
+        return this.sizeMap.lowerEntry(key);
     }
     
     public Float lowerKey(Float key) {
-        return sizeMap.lowerKey(key);
+        return this.sizeMap.lowerKey(key);
     }
     
     public Map.Entry<Float, Integer> floorEntry(Float key) {
-        return sizeMap.floorEntry(key);
+        return this.sizeMap.floorEntry(key);
     }
     
     public Float floorKey(Float key) {
-        return sizeMap.floorKey(key);
+        return this.sizeMap.floorKey(key);
     }
     
     public Map.Entry<Float, Integer> ceilingEntry(Float key) {
-        return sizeMap.ceilingEntry(key);
+        return this.sizeMap.ceilingEntry(key);
     }
     
     public Float ceilingKey(Float key) {
-        return sizeMap.ceilingKey(key);
+        return this.sizeMap.ceilingKey(key);
     }
 
     public Map.Entry<Float, Integer> higherEntry(Float key) {
-        return sizeMap.higherEntry(key);
+        return this.sizeMap.higherEntry(key);
     }
     
     public Float higherKey(Float key) {
-        return sizeMap.higherKey(key);
+        return this.sizeMap.higherKey(key);
     }
 
     public Set<Float> keySet() {
-        return sizeMap.keySet();
+        return this.sizeMap.keySet();
     }
     
     public Collection<Integer> values() {
-        return sizeMap.values();
+        return this.sizeMap.values();
     }
     
     public Set<Map.Entry<Float, Integer>> entrySet() {
-        return sizeMap.entrySet();
+        return this.sizeMap.entrySet();
     }
 }

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/common/entities/jellyfish/helper/JellyfishSizeMap.java
@@ -1,0 +1,120 @@
+package com.minecraftabnormals.upgrade_aquatic.common.entities.jellyfish.helper;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class JellyfishSizeMap {
+    protected final TreeMap<Float, Integer> sizeMap;
+    protected final int weightTotal;
+
+    public JellyfishSizeMap(TreeMap<Float, Integer> map) {
+        this.sizeMap = map;
+        int weightTotal = 0;
+        for (int weight : this.sizeMap.values())
+            weightTotal += weight;
+        this.weightTotal = weightTotal;
+    }
+
+    public int size() {
+        return sizeMap.size();
+    }
+
+    public int totalWeight() {
+        return this.weightTotal;
+    }
+
+    public Float randomSize(Random rand) throws RuntimeException {
+        int denominator = totalWeight();
+        for (Map.Entry<Float, Integer> sizeEntry : this.entrySet()) {
+            int weight = sizeEntry.getValue();
+            if (rand.nextInt(denominator) < weight) {
+                return sizeEntry.getKey();
+            }
+            denominator = denominator - weight;
+        }
+       throw new RuntimeException("JellyfishSizeMap in Upgrade Aquatic has broken. This should not be happening!");
+    }
+
+    public boolean containsKey(Float key) {
+        return sizeMap.containsKey(key);
+    }
+
+    public boolean containsValue(Integer value) {
+        return sizeMap.containsValue(value);
+    }
+
+    public Integer get(Float key) {
+        return sizeMap.get(key);
+    }
+
+    public Comparator<? super Float> comparator() {
+        return sizeMap.comparator();
+    }
+
+    public Float firstKey() {
+        return sizeMap.firstKey();
+    }
+
+    public Float lastKey() {
+        return sizeMap.lastKey();
+    }
+
+    public Map.Entry<Float, Integer> firstEntry() {
+        return sizeMap.firstEntry();
+    }
+    
+    public Map.Entry<Float, Integer> lastEntry() {
+        return sizeMap.lastEntry();
+    }
+    
+    public Map.Entry<Float, Integer> lowerEntry(Float key) {
+        return sizeMap.lowerEntry(key);
+    }
+    
+    public Float lowerKey(Float key) {
+        return sizeMap.lowerKey(key);
+    }
+    
+    public Map.Entry<Float, Integer> floorEntry(Float key) {
+        return sizeMap.floorEntry(key);
+    }
+    
+    public Float floorKey(Float key) {
+        return sizeMap.floorKey(key);
+    }
+    
+    public Map.Entry<Float, Integer> ceilingEntry(Float key) {
+        return sizeMap.ceilingEntry(key);
+    }
+    
+    public Float ceilingKey(Float key) {
+        return sizeMap.ceilingKey(key);
+    }
+
+    public Map.Entry<Float, Integer> higherEntry(Float key) {
+        return sizeMap.higherEntry(key);
+    }
+    
+    public Float higherKey(Float key) {
+        return sizeMap.higherKey(key);
+    }
+
+    public Set<Float> keySet() {
+        return sizeMap.keySet();
+    }
+    
+    public Collection<Integer> values() {
+        return sizeMap.values();
+    }
+    
+    public Set<Map.Entry<Float, Integer>> entrySet() {
+        return sizeMap.entrySet();
+    }
+}


### PR DESCRIPTION
Bagel suggested this feature a while ago, but I abandoned it due to a freezing issue. This PR reimplements it using IAgeableEntity, allowing the jellyfish to be grown between sizes 0.5, 0.65 and 1.0 (which they naturally spawn with).