### PR TITLE
Converted fish bucket dispense behaviors to non overriding system

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ modName=Upgrade Aquatic
 modId=upgrade_aquatic
 modVersion=3.0.0
 
-abnormalsCore=3147409
+abnormalsCore=3157757

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
@@ -129,8 +129,8 @@ public class UADispenseBehaviorRegistry {
                     }
                 }
             }
-            return stack; //Should never be reached
-		}
+            return stack;
+	}
     };
 
 	public static void registerDispenseBehaviors() {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
@@ -130,7 +130,7 @@ public class UADispenseBehaviorRegistry {
                 }
             }
             return stack;
-		}
+	}
     };
 
 	public static void registerDispenseBehaviors() {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
@@ -3,6 +3,7 @@ package com.minecraftabnormals.upgrade_aquatic.core.other;
 import com.minecraftabnormals.abnormals_core.common.dispenser.FishBucketDispenseBehavior;
 import com.minecraftabnormals.abnormals_core.core.api.IBucketableEntity;
 import com.minecraftabnormals.abnormals_core.core.util.BlockUtil;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.upgrade_aquatic.client.particle.UAParticles;
 import com.minecraftabnormals.upgrade_aquatic.common.entities.pike.PikeEntity;
 import com.minecraftabnormals.upgrade_aquatic.common.items.GlowingInkItem;
@@ -128,8 +129,8 @@ public class UADispenseBehaviorRegistry {
                     }
                 }
             }
-            return new FishBucketDispenseBehavior().dispense(source, stack);
-        }
+            return stack; //Should never be reached
+		}
     };
 
 	public static void registerDispenseBehaviors() {
@@ -138,7 +139,7 @@ public class UADispenseBehaviorRegistry {
 		DispenserBlock.registerDispenseBehavior(UAItems.LIONFISH_BUCKET.get(), new FishBucketDispenseBehavior());
 		DispenserBlock.registerDispenseBehavior(UAItems.SQUID_BUCKET.get(), new FishBucketDispenseBehavior());
 		DispenserBlock.registerDispenseBehavior(UAItems.GLOW_SQUID_BUCKET.get(), new FishBucketDispenseBehavior());
-		DispenserBlock.registerDispenseBehavior(Items.WATER_BUCKET, bucketFishItemBehavior);
+		DataUtil.registerAlternativeDispenseBehavior(Items.WATER_BUCKET, (source, stack) -> !BlockUtil.getEntitiesAtOffsetPos(source, WaterMobEntity.class, entity -> entity instanceof AbstractFishEntity || entity instanceof IBucketableEntity || entity instanceof SquidEntity).isEmpty(), bucketFishItemBehavior);
 		
 		DispenserBlock.registerDispenseBehavior(Items.INK_SAC, inkDispenseBehavior);
 		DispenserBlock.registerDispenseBehavior(UAItems.GLOWING_INK_SAC.get(), glowingInkDispenseBehavior);

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
@@ -130,7 +130,7 @@ public class UADispenseBehaviorRegistry {
                 }
             }
             return stack;
-	}
+		}
     };
 
 	public static void registerDispenseBehaviors() {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/other/UADispenseBehaviorRegistry.java
@@ -130,7 +130,7 @@ public class UADispenseBehaviorRegistry {
                 }
             }
             return stack;
-	}
+        }
     };
 
 	public static void registerDispenseBehaviors() {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -31,6 +31,6 @@ license = "https://github.com/team-abnormals/upgrade-aquatic/blob/main/LICENSE.t
 [[dependencies.upgrade_aquatic]]
     modId = "abnormals_core"
     mandatory = true
-    versionRange = "[3.0.4,)"
+    versionRange = "[3.0.6,)"
     ordering = "AFTER"
     side = "BOTH"


### PR DESCRIPTION
Minor change, essentially just replacing the `FishBucketDispenseBehavior` that was used as a fallback with whatever the previous behavior was at registry time, increasing compatibility with other mods.