### PR TITLE
Register UA config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/UAConfig.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/UAConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.upgrade_aquatic.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import org.apache.commons.lang3.tuple.Pair;
@@ -7,25 +8,58 @@ import org.apache.commons.lang3.tuple.Pair;
 public class UAConfig {
 
 	public static class Common {
+
+		@ConfigKey("clerics_buy_thrasher_teeth")
 		public final ConfigValue<Boolean> clericsBuyThrasherTeeth;
+
+		@ConfigKey("drowned_has_swimming_animation")
 		public final ConfigValue<Boolean> drownedSwimmingAnimation;
+
+		@ConfigKey("leatherworkers_sell_bedrolls")
 		public final ConfigValue<Boolean> leatherworkersSellBedrolls;
 
+
+		@ConfigKey("deep_ocean_mob_max_spawn_height")
 		public final ConfigValue<Integer> deepOceanMobMaxHeight;
 
+
+		@ConfigKey("glow_squid_weight")
 		public final ConfigValue<Integer> glowSquidWeight;
+
+		@ConfigKey("thrasher_weight")
 		public final ConfigValue<Integer> thrasherWeight;
+
+		@ConfigKey("nautilus_weight")
 		public final ConfigValue<Integer> nautilusWeight;
+
+		@ConfigKey("lionfish_weight")
 		public final ConfigValue<Integer> lionfishWeight;
+
+		@ConfigKey("pike_weight")
 		public final ConfigValue<Integer> pikeWeight;
+
+		@ConfigKey("perch_weight")
 		public final ConfigValue<Integer> perchWeight;
+
+		@ConfigKey("pike_weight_swamp")
 		public final ConfigValue<Integer> pikeSwampWeight;
+
+		@ConfigKey("lionfish_weight_swamp")
 		public final ConfigValue<Integer> squidSwampWeight;
 
+		@ConfigKey("beachgrass_frequency")
 		public final ConfigValue<Integer> beachgrassFrequency;
+
+		@ConfigKey("searocket_frequency")
 		public final ConfigValue<Integer> searocketFrequency;
+
+		@ConfigKey("pickerelweed_frequency")
 		public final ConfigValue<Integer> pickerelweedFrequency;
+
+		@ConfigKey("pickerelweed_frequency_extra")
 		public final ConfigValue<Integer> pickerelweedExtraFrequency;
+
+		@ConfigKey("flowering_rush_frequency")
 		public final ConfigValue<Integer> floweringRushFrequency;
 
 		public Common(ForgeConfigSpec.Builder builder) {
@@ -66,7 +100,11 @@ public class UAConfig {
 	}
 
 	public static class Client {
+
+		@ConfigKey("show_unobtainable_description")
 		public final ConfigValue<Boolean> showUnobtainableDescription;
+
+		@ConfigKey("days_till_insomnia_overlay")
 		public final ConfigValue<Integer> daysTillRenderInsomniaOverlay;
 
 		public Client(ForgeConfigSpec.Builder builder) {

--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/UpgradeAquatic.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/UpgradeAquatic.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.upgrade_aquatic.core;
 
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.upgrade_aquatic.client.GlowSquidSpriteUploader;
 import com.minecraftabnormals.upgrade_aquatic.client.particle.UAParticles;
@@ -60,6 +61,7 @@ public class UpgradeAquatic {
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, UAConfig.COMMON_SPEC);
 		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, UAConfig.CLIENT_SPEC);
+		DataUtil.registerConfigCondition(UpgradeAquatic.MOD_ID, UAConfig.COMMON, UAConfig.CLIENT);
 	}
 
 	private void setupCommon(final FMLCommonSetupEvent event) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.