### PR TITLE
Fix Dead Star Coral Fan's loot table

### DIFF
--- a/src/main/resources/data/upgrade_aquatic/loot_tables/blocks/dead_star_coral_fan.json
+++ b/src/main/resources/data/upgrade_aquatic/loot_tables/blocks/dead_star_coral_fan.json
@@ -6,7 +6,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "upgrade_aquatic:star_coral_fan"
+          "name": "upgrade_aquatic:dead_star_coral_fan"
         }
       ],
       "conditions": [


### PR DESCRIPTION
This fixes issue stated in https://github.com/team-abnormals/upgrade-aquatic/issues/296.